### PR TITLE
Sort files because "recursive_directory_iterator" is too arbitrary

### DIFF
--- a/source/utils.cpp
+++ b/source/utils.cpp
@@ -27,6 +27,7 @@ std::vector<fs::path> getDirectoryFiles(const std::string & dir, const std::vect
             }
         }
     }
+    std::sort(files.begin(), files.end());
     std::reverse(files.begin(), files.end());
     return files;
 }


### PR DESCRIPTION
(Partially) Fixes #2 