### PR TITLE
Add chevereto template

### DIFF
--- a/config/hoster/chevereto.json
+++ b/config/hoster/chevereto.json
@@ -1,0 +1,7 @@
+{
+    "Url": "https://[CHEVERETO_SITE_URL]/api/1/upload/?key=[API_KEY]",
+    "Regex": "",
+    "ImageName": "source",
+    "VideoName": "",
+    "Show Response": false
+}


### PR DESCRIPTION
Add template for Chevereto API uploads. https://v3-docs.chevereto.com/API/V1.html

Alternatively you can append `&format=txt` to the end of the URL after the API key so that you could enable "Show Response" and see the photo URL on the switch display. My use case this does not matter as I just pull the URL from my Chevereto instance if I need it. The URL for my instance also ends up too long to actually display entirely on the display of the Switch. Chevereto is a great tool to archive photos off the device wireless.